### PR TITLE
fix app load

### DIFF
--- a/src/config/application.rb
+++ b/src/config/application.rb
@@ -13,8 +13,6 @@ module Scfair
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
-    config.autoload_paths << Rails.root.join('lib')
-    config.eager_load_paths << Rails.root.join('lib')
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/src/config/initializers/load_libs.rb
+++ b/src/config/initializers/load_libs.rb
@@ -1,3 +1,0 @@
-Dir[Rails.root.join('lib/**/*.rb')].each do |file|
-  require file
-end


### PR DESCRIPTION
The app loading `Rails.application.eager_load!` does not work properly because it's trying to load rake tasks `/lib/tasks`, which are not meant to be reloaded or eager loaded.